### PR TITLE
[add]front:userの投稿一覧実装 back:current_userメソッドの実装及びuserの投稿のcontroller実装

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -7,7 +7,7 @@ module Api
       # end
 
       def index
-        posts = Post.includes(:category).all
+        posts = Post.includes(:category).order(created_at: :desc).all
         posts_with_category_names = posts.map do |post|
           post.attributes.merge({ 'category_name' => post.category.name })
         end

--- a/back/app/controllers/api/v1/user_posts_controller.rb
+++ b/back/app/controllers/api/v1/user_posts_controller.rb
@@ -1,0 +1,17 @@
+class Api::V1::UserPostsController < ApplicationController
+  before_action :set_current_user
+
+  def index
+    posts = @current_user.posts.includes(:category).order(created_at: :desc)
+    posts_with_category_names = posts.map do |post|
+      post.attributes.merge({ 'category_name' => post.category.name })
+    end
+    render json: posts
+  end
+
+  private
+  
+  def post_params
+    params.require(:post).permit(:title, :description, :start_date, :end_date, :recruiting_count)
+  end
+end

--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -1,2 +1,44 @@
+require 'net/http'
+require 'uri'
+require 'json'
+
 class ApplicationController < ActionController::API
+  include ActionController::Cookies
+
+  private
+
+  def set_current_user
+    Rails.logger.info "Current session: #{session.inspect}"  # セッション情報をログに出力
+    received_access_token = request.headers["Authorization"].split(' ').last
+
+    if session[:user_id] && session[:access_token] == received_access_token
+      
+      # セッションからユーザー情報を取得
+      @current_user = User.find_by(id: session[:user_id])
+    else
+      # GitHub APIからユーザー情報を取得
+      session.delete(:access_token)
+      user_info = fetch_user_info_from_github(received_access_token)
+
+      # GitHubのuidをもとにユーザー検索
+      @current_user = User.find_by(uid: user_info['id'])
+
+      # セッションにユーザー情報を保存
+      session[:user_id] = @current_user.id
+      session[:access_token] = received_access_token
+    end
+  end
+
+  # GiHtubのユーザー情報を取得
+  def fetch_user_info_from_github(access_token)
+    uri = URI.parse("https://api.github.com/user")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer #{access_token}"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+      http.request(request)
+    end
+
+    JSON.parse(response.body)
+  end
 end

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -22,6 +22,9 @@ module App
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore
+
     config.api_only = true
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local

--- a/front/src/app/components/Header.tsx
+++ b/front/src/app/components/Header.tsx
@@ -19,7 +19,7 @@ const Header = () => {
         <nav>
           <ul className="flex space-x-6 items-center">
             <li>
-              <Link href="/posts/index">
+              <Link href="/posts">
                 <div className="flex items-center text-white hover:text-blue-400">
                   <FaListAlt className="mr-2" />募集一覧
                 </div>
@@ -33,7 +33,7 @@ const Header = () => {
               </Link>
             </li>
             <li>
-              <Link href="/user_posts/index">
+              <Link href="/user/posts">
                 <div className="flex items-center text-white hover:text-blue-400">
                   <FaUserCircle className="mr-2" />マイエリア
                 </div>

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -19,10 +19,12 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={inter.className}>
+      <body className={`${inter.className} flex flex-col min-h-screen`}>
         <NextAuthProvider>
           <Header />
-            {children}
+            <main className="flex-1">
+              {children}
+            </main>
           <Footer />
         </NextAuthProvider>
       </body>

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import React, { useState } from "react";
+import { useSession } from 'next-auth/react';
+import Image from 'next/image'
+import useSWR from 'swr';
+import fetcherWithAuth from '../utils/fetcher'
+import Link from 'next/link'
+import camelcaseKeys from "camelcase-keys";
+
+interface Post {
+  [key: string]: unknown; 
+  id: bigint,
+  title: string,
+  startDate: Date,
+  endDate: Date,
+  recruitingCount: bigint,
+  description: string,
+  status: string,
+  categoryName: string
+}
+
+export default function Posts() {
+  const { data: session, status } = useSession();
+  const { data: rawPosts, error } = useSWR<Post[]>('/api/v1/posts', fetcherWithAuth); // fetcherWithAuthを使用
+  const posts = rawPosts ? rawPosts.map((post :Post) => camelcaseKeys(post, {deep:true})) : null;
+
+  if (status === "loading") {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <Image src="/loading.svg" width={500} height={500} alt="loading..." className="animate-spin" />
+      </div>
+    );
+  }
+  
+  if (error) return <p className="text-center text-red-500">エラーが発生しました。</p>;
+
+  return (
+    <div className="container mx-auto px-4 py-6">
+      {status === "authenticated" ? (
+        <div>
+          <h1 className="text-3xl font-bold text-center py-4 my-6 text-gray-900">募集一覧</h1>
+          <div className="grid grid-cols-3 gap-16">
+            {posts?.map((post :any) => (
+              <div
+                key={post.id}
+                className="bg-gray-100 p-4 rounded-lg shadow-lg transform hover:scale-105 hover:shadow-2xl transition-all duration-300"
+              >
+                <h2 className="text-xl font-semibold mb-2">{post.title}</h2>
+                <p>{post.description}</p>
+                <div>{post.title}</div>
+                <div>{post.startDate}</div>
+                <div>{post.endDate}</div>
+                <div>{post.recruitingCount}</div>
+                <div>{post.status}</div>
+                <div>{post.categoryName}</div>
+                
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <h1 className="text-center text-xl text-gray-800">ログインしてください</h1>
+      )}
+    </div>
+  );
+}

--- a/front/src/app/user/posts/page.tsx
+++ b/front/src/app/user/posts/page.tsx
@@ -1,11 +1,10 @@
 "use client";
 import React, { useState } from "react";
 import { useSession } from 'next-auth/react';
-import Image from 'next/image'
 import useSWR from 'swr';
 import fetcherWithAuth from '../../utils/fetcher'
-import Link from 'next/link'
 import camelcaseKeys from "camelcase-keys";
+import Image from 'next/image'
 
 interface Post {
   [key: string]: unknown; 
@@ -19,10 +18,9 @@ interface Post {
   categoryName: string
 }
 
-export default function Home() {
+export default function UserPosts() {
   const { data: session, status } = useSession();
-  console.log(useSession());
-  const { data: rawPosts, error } = useSWR<Post[]>('/api/v1/posts', fetcherWithAuth); // fetcherWithAuthを使用
+  const { data: rawPosts, error } = useSWR('/api/v1/user_posts', fetcherWithAuth); // fetcherWithAuthを使用
   const posts = rawPosts ? rawPosts.map((post :Post) => camelcaseKeys(post, {deep:true})) : null;
 
   if (status === "loading") {


### PR DESCRIPTION
## 概要
current_userメソッドの実装及びユーザに紐づく投稿一覧表示の実装
Related to #37 

## フロントエンド
ユーザーに紐づく投稿一覧表示の実装

## バックエンド
accessTokenを用いたcurrent_userメソッドの実装。
バックエンド側でGitHubにリクエストをして、情報を取得するようにした。
その情報を用いてuserテーブルと照合してcurrent_userメソッドを作成する。