### PR TITLE
[add]front:入力フォーム実装 back:current_userに紐づく投稿処理の実装

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -9,7 +9,11 @@ module Api
       def index
         posts = Post.includes(:category).order(created_at: :desc).all
         posts_with_category_names = posts.map do |post|
-          post.attributes.merge({ 'category_name' => post.category.name })
+          post.attributes.merge({ 
+            'category_name' => post.category.name,
+            'start_date' => post.formatted_start_date,
+            'end_date' => post.formatted_end_date,
+            })
         end
         render json: posts_with_category_names
       end

--- a/back/app/controllers/api/v1/user_posts_controller.rb
+++ b/back/app/controllers/api/v1/user_posts_controller.rb
@@ -4,14 +4,30 @@ class Api::V1::UserPostsController < ApplicationController
   def index
     posts = @current_user.posts.includes(:category).order(created_at: :desc)
     posts_with_category_names = posts.map do |post|
-      post.attributes.merge({ 'category_name' => post.category.name })
+      post.attributes.merge({ 
+        'category_name' => post.category.name,
+        'start_date' => post.formatted_start_date,
+        'end_date' => post.formatted_end_date,
+         })
     end
-    render json: posts
+    render json: posts_with_category_names
+  end
+
+  def create
+    post = @current_user.posts.new(post_params)
+
+    if post.save
+      success_message = I18n.t('flash.posts.create.success')
+      render json: { status: 'success', message: success_message, data: post }, status: :created
+    else
+      failure_message = I18n.t('flash.posts.create.failure')
+      render json: { status: 'failure', message: failure_message, data: post }, status: :unprocessable_entity
+    end
   end
 
   private
   
   def post_params
-    params.require(:post).permit(:title, :description, :start_date, :end_date, :recruiting_count)
+    params.require(:post).permit(:title, :description, :start_date, :end_date, :recruiting_count, :status, :category_id)
   end
 end

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,4 +1,21 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :category
+
+  validates :category_id, presence: true
+  validates :title, presence: true #, length: { maximum: 12 }
+  validates :start_date, presence: true
+  validates :end_date, presence: true
+  validates :recruiting_count, presence: true
+  validates :description, presence: true
+  validates :status, presence: true
+  
+
+  def formatted_start_date
+    start_date.strftime("%Y-%m-%d %H:%M:%S")
+  end
+
+  def formatted_end_date
+    end_date.strftime("%Y-%m-%d %H:%M:%S")
+  end
 end

--- a/back/config/locales/ja.yml
+++ b/back/config/locales/ja.yml
@@ -1,0 +1,6 @@
+ja:
+  flash:
+    posts:
+      create:
+        success: "投稿が正常に作成されました。"
+        failure: "投稿の作成に失敗しました。"

--- a/back/db/seeds.rb
+++ b/back/db/seeds.rb
@@ -1,55 +1,44 @@
-# データを全消しする
+# db/seeds.rb
+
+# 既存のデータをクリア
 Post.delete_all
 Category.delete_all
 User.delete_all
 
+ActiveRecord::Base.connection.reset_pk_sequence!('categories')
+ActiveRecord::Base.connection.reset_pk_sequence!('posts')
+ActiveRecord::Base.connection.reset_pk_sequence!('users')
+
+# ユーザーを作成
+users = User.create([
+  { provider: "github", avatar_url: "https://avatars.githubusercontent.com/u/131367248?v=4", uid: "122", name: "ざっきー" },
+  { provider: "github", avatar_url: "https://example.com/avatar0.png", uid: "100", name: "ユーザー1" },
+  { provider: "github", avatar_url: "https://example.com/avatar1.png", uid: "101", name: "ユーザー2" },
+  { provider: "github", avatar_url: "https://example.com/avatar2.png", uid: "102", name: "ユーザー3" },
+  { provider: "github", avatar_url: "https://example.com/avatar3.png", uid: "103", name: "ユーザー4" }
+])
+
 # カテゴリーを作成
-categories = ["チーム開発", "ペアプログラミング", "GitHub-Flow"].map do |name|
-  Category.create!(name: name)
-end
+categories = Category.create([
+  { name: "チーム開発" },
+  { name: "ペアプログラミング" },
+  { name: "GitHub-Flow" }
+])
 
-# 特定のユーザーを作成または取得（既に存在する場合）
-user = User.find_or_create_by(uid: "131367248") do |u|
-  u.provider = "github"
-  u.avatar_url = "https://avatars.githubusercontent.com/u/131367248?v=4"
-  u.name = "ざっきー"
-end
-
-# 特定のユーザーに対してポストを作成
-3.times do |i|
-  Post.create!(
-    user_id: user.id,
-    category_id: categories.sample.id,  # ランダムにカテゴリを選択し、そのIDを設定
-    title: "Post #{i+1} by ざっきー",
-    start_date: Time.now,
-    end_date: Time.now + 5.days,
-    recruiting_count: 5,
-    description: "This is a sample post #{i+1} by ざっきー.",
-    status: 'open'
-  )
-end
-
-# 新しいユーザーとそのポストを作成
-3.times do |n|
-  new_user = User.create!(
-    provider: "github",
-    avatar_url: "https://example.com/avatar#{n}.png",
-    uid: "#{n+100}",
-    name: "ユーザー#{n+1}"
-  )
-
-  3.times do |i|
-    Post.create!(
-      user: new_user,
-      category_id: categories.sample.id,  # ランダムにカテゴリを選択し、そのIDを設定
-      title: "Post #{i+1} by ユーザー#{n+1}",
-      start_date: Time.now,
-      end_date: Time.now + 5.days,
+# 各ユーザーに対して投稿を作成
+users.each_with_index do |user, index|
+  Post.create([
+    {
+      user: user,
+      category: categories[index % categories.length],
+      title: "サンプル投稿 #{index + 1}",
+      start_date: Date.today,
+      end_date: Date.today + 5.days,
       recruiting_count: 5,
-      description: "This is a sample post #{i+1} by ユーザー#{n+1}.",
-      status: 'open'
-    )
-  end
+      description: "#{user.name}による投稿。",
+      status: "open"
+    }
+  ])
 end
 
 puts "Seed data created!"

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,7 @@
       "name": "front",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^3.3.4",
         "axios": "^1.6.2",
         "camelcase-keys": "^9.1.2",
         "ewr": "^1.0.0",
@@ -15,8 +16,11 @@
         "next-auth": "^4.24.5",
         "react": "^18",
         "react-dom": "^18",
+        "react-hook-form": "^7.49.2",
         "react-icons": "^4.12.0",
-        "swr": "^2.2.4"
+        "react-toastify": "^9.1.3",
+        "swr": "^2.2.4",
+        "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -116,6 +120,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-3.3.4.tgz",
+      "integrity": "sha512-o5cgpGOuJYrd+iMKvkttOclgwRW86EsWJZZRC23prf0uU2i48Htq4PuT73AVb9ionFyZrwYEITuOFGF+BydEtQ==",
+      "peerDependencies": {
+        "react-hook-form": "^7.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1171,6 +1183,14 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -3881,6 +3901,22 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.49.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.49.2.tgz",
+      "integrity": "sha512-TZcnSc17+LPPVpMRIDNVITY6w20deMdNi6iehTFLV1x8SqThXGwu93HjlUVU09pzFgZH7qZOvLMM7UYf2ShAHA==",
+      "engines": {
+        "node": ">=18",
+        "pnpm": "8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-icons": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
@@ -3894,6 +3930,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-toastify": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
+      "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "dependencies": {
+        "clsx": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -5030,6 +5078,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/front/package.json
+++ b/front/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
     "axios": "^1.6.2",
     "camelcase-keys": "^9.1.2",
     "ewr": "^1.0.0",
@@ -16,8 +17,11 @@
     "next-auth": "^4.24.5",
     "react": "^18",
     "react-dom": "^18",
+    "react-hook-form": "^7.49.2",
     "react-icons": "^4.12.0",
-    "swr": "^2.2.4"
+    "react-toastify": "^9.1.3",
+    "swr": "^2.2.4",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/front/src/app/components/Header.tsx
+++ b/front/src/app/components/Header.tsx
@@ -26,7 +26,7 @@ const Header = () => {
               </Link>
             </li>
             <li>
-              <Link href="/user_posts/create">
+              <Link href="/user/posts/new">
                 <div className="flex items-center text-white hover:text-blue-400">
                   <FaPlusCircle className="mr-2" />新規募集
                 </div>

--- a/front/src/app/posts/page.tsx
+++ b/front/src/app/posts/page.tsx
@@ -45,15 +45,13 @@ export default function Posts() {
                 key={post.id}
                 className="bg-gray-100 p-4 rounded-lg shadow-lg transform hover:scale-105 hover:shadow-2xl transition-all duration-300"
               >
-                <h2 className="text-xl font-semibold mb-2">{post.title}</h2>
-                <p>{post.description}</p>
-                <div>{post.title}</div>
-                <div>{post.startDate}</div>
-                <div>{post.endDate}</div>
-                <div>{post.recruitingCount}</div>
-                <div>{post.status}</div>
-                <div>{post.categoryName}</div>
-                
+                <h2 className="text-xl font-semibold mb-2">タイトル:{post.title}</h2>
+                <div>カテゴリ:{post.categoryName}</div>
+                <div>人数:{post.recruitingCount}</div>
+                <div>ステータス:{post.status}</div>
+                <div>開始予定日:{post.startDate}</div>
+                <div>終了予定日:{post.endDate}</div>
+                <div>募集概要:{post.description}</div>
               </div>
             ))}
           </div>

--- a/front/src/app/user/posts/new/page.tsx
+++ b/front/src/app/user/posts/new/page.tsx
@@ -1,0 +1,195 @@
+"use client"
+
+import React from 'react';
+import axios from 'axios';
+import { getSession } from 'next-auth/react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from "zod";
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+interface FormData {
+  title: string;
+  start_date: string;
+  end_date: string;
+  recruiting_count: number;
+  status: 'open' | 'closed'; // 'open' または 'closed' のみを受け入れる
+  description: string;
+  category_id: number;
+}
+
+const postSchema = z.object({
+  title: z.string().min(2, { message: "タイトルは少なくとも5文字以上必要です。" }),
+  start_date: z.string().nonempty({ message: "開始日は必須です。" }),
+  end_date: z.string().nonempty({ message: "終了日は必須です。" }),
+  recruiting_count: z.number().min(2).max(20, { message: "募集人数は2から20の間である必要があります。" }),
+  description: z.string().min(10, { message: "少なくとも10文字以上の入力が必要です。" }),
+  status: z.enum(['open', 'closed']).refine(val => ['open', 'closed'].includes(val), { 
+    message: "ステータスは'open'または'closed'である必要があります。" 
+  }),
+  category_id: z.number().nonnegative({ message: "カテゴリーIDは正の数である必要があります。" })
+});
+
+export default function PostForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
+    resolver: zodResolver(postSchema),
+  });
+  // const [title, setTitle] = useState('');
+  // const [startDate, setStartDate] = useState('');
+  // const [endDate, setEndDate] = useState('');
+  // const [recruitingCount, setRecruitingCount] = useState(2);
+  // const [description, setDescription] = useState('');
+  // const [status, setStatus] = useState('');
+  // const [category_id, setCategoryName] = useState(1);
+
+  const createPost = async (formData :FormData) => { 
+    // フォームのバリデーションなどのロジックをここに追加
+    //if (!title || !startDate || !endDate || !description) return;
+    const session = await getSession();
+    const token = session?.accessToken;
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+    const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost';
+    const url = `${apiUrl}/api/v1/user_posts`;
+    const postData = {
+      post: {
+        title: formData.title,
+        start_date: formData.start_date,
+        end_date: formData.end_date,
+        recruiting_count: formData.recruiting_count,
+        status: formData.status,
+        description: formData.description,
+        category_id: formData.category_id
+      }
+    };
+
+    try {
+      const response = await axios.post(url, postData, {
+        headers: headers,
+        withCredentials: true
+      });
+      toast.success(response.data.message);
+      console.log(response.data);  // 成功した場合の処理
+
+    } catch (error: unknown) {
+      // エラーオブジェクトがAxiosError型のインスタンスであるかをチェック
+      if (axios.isAxiosError(error)) {
+        console.log(error)
+        // エラーレスポンスが存在し、その中にメッセージがある場合は表示する
+        if (error.response && error.response.data && typeof error.response.data.message === 'string') {
+          console.log(error.response)
+          toast.error(error.response.data.message);
+        } else {
+          // その他のエラーの場合は汎用的なメッセージを表示
+          toast.error("投稿に問題が発生しました");
+        }
+      }
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6 bg-white shadow-lg rounded-lg">
+      <h2 className="text-3xl font-semibold mb-6 text-center text-gray-800">新しい投稿を作成</h2>
+      <form onSubmit={handleSubmit(createPost)} className="space-y-8">
+      <ToastContainer />
+        
+        {/* タイトルフィールド */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">タイトル</label>
+          <input
+            type="text"
+            className="form-input mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("title")}
+          />
+          {errors.title && <p className="text-red-600 text-sm">{errors.title.message}</p>}
+        </div>
+        
+        {/* 開始日フィールド */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">開始日</label>
+          <input
+            type="datetime-local"
+            className="form-input mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("start_date")}
+          />
+          {errors.start_date && <p className="text-red-600 text-sm">{errors.start_date.message}</p>}
+        </div>
+        
+        {/* 終了日フィールド */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">終了日</label>
+          <input
+            type="datetime-local"
+            className="form-input mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("end_date")}
+          />
+          {errors.end_date && <p className="text-red-600 text-sm">{errors.end_date.message}</p>}
+        </div>
+        
+        {/* 募集人数フィールド */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">募集人数</label>
+          <select
+            className="form-select mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("recruiting_count", { valueAsNumber: true })}
+          >
+            {[...Array(19)].map((_, i) => (
+              <option key={i + 2} value={i + 2}>
+                {i + 2}
+              </option>
+            ))}
+          </select>
+          {errors.recruiting_count && <p className="text-red-600 text-sm">{errors.recruiting_count.message}</p>}
+        </div>
+
+        {/* 公開ステータス */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">公開ステータス</label>
+          <select className="form-select mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("status")}
+          >
+            <option value="open">公開中</option>
+            <option value="closed">締め切り</option>
+          </select>
+          {errors.status && <p className="text-red-600 text-sm">{errors.status.message}</p>}
+        </div>
+
+        {/* カテゴリー */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">募集カテゴリ</label>
+          <select className="form-select mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("category_id", { valueAsNumber: true })}
+          >
+            <option value={1}>チーム開発</option>
+            <option value={2}>ペアプロ</option>
+            <option value={3}>GitHub-Flow</option>
+          </select>
+          {errors.category_id && <p className="text-red-600 text-sm">{errors.category_id.message}</p>}
+        </div>
+
+        
+        {/* 説明フィールド */}
+        <div className="space-y-2">
+          <label className="block text-lg font-medium text-gray-700">募集概要</label>
+          <textarea
+            className="form-textarea mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+            {...register("description")}
+          ></textarea>
+          {errors.description && <p className="text-red-600 text-sm">{errors.description.message}</p>}
+        </div>
+        
+        {/* 送信ボタン */}
+        <div className="flex justify-center">
+          <button 
+            type="submit" 
+            className="px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+          >
+            投稿
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+  
+}

--- a/front/src/app/user/posts/page.tsx
+++ b/front/src/app/user/posts/page.tsx
@@ -44,15 +44,13 @@ export default function UserPosts() {
                 key={post.id}
                 className="bg-gray-100 p-4 rounded-lg shadow-lg transform hover:scale-105 hover:shadow-2xl transition-all duration-300"
               >
-                <h2 className="text-xl font-semibold mb-2">{post.title}</h2>
-                <p>{post.description}</p>
-                <div>{post.title}</div>
-                <div>{post.startDate}</div>
-                <div>{post.endDate}</div>
-                <div>{post.recruitingCount}</div>
-                <div>{post.status}</div>
-                <div>{post.categoryName}</div>
-                
+                <h2 className="text-xl font-semibold mb-2">タイトル:{post.title}</h2>
+                <div>カテゴリ:{post.categoryName}</div>
+                <div>人数:{post.recruitingCount}</div>
+                <div>ステータス:{post.status}</div>
+                <div>開始予定日:{post.startDate}</div>
+                <div>終了予定日:{post.endDate}</div>
+                <div>募集概要:{post.description}</div>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## 概要
current_userに紐づいた募集投稿処理を実装しました。
current_usetメソッドは前回のプルリク（ https://github.com/zakkiiy/pairdev/pull/44 ）で、実装済みとなります。

## フロントエンド
募集投稿の入力フォームを実装。
バリデーションの実装

## バックエンド
認証済みユーザー用のpostコントローラーの実装
バリデーションの実装
フラッシュメッセージの実装

## レビュー確認方法

不明点やエラーが出力された際は、ご連絡いただけますと幸いです。

### 環境構築

- バックエンド側
```bash
cd back
docker compose build
docker-compose run --rm web rails db:create
docker-compose run --rm web rails db:migrate
docker-compose run --rm web rails db:seed
docker compose up
```

- フロントエンド側
```bash
cd front
npm install
npm run dev
```

### 確認内容
1. GitHubログインを実施後、ヘッダーの「新規募集」をクリックする。
2. 入力内容をそのまま、「投稿」をクリックして、バリデーションエラーが出力されていることを確認する。
  ※日付の矛盾等はまだ考慮できてないためエラーが確認できれば大丈夫です。
    - タイトル：タイトルは少なくとも5文字以上必要です。
    - 開始日：開始日は必須です。
    - 終了日：終了日は必須です。
    - 募集概要：少なくとも10文字以上の入力が必要です。
    
3. 投稿の失敗によるフラッシュメッセージの確認。
    - back/app/models/post.rbの6行目の「#, length: { maximum: 12 }」の#を外す。
    - タイトルを13文字以上入力する。開始日、終了日、募集概要を適当に入力して「投稿」をクリックする。
    - 「投稿の作成に失敗しました」というフラッシュメッセージが出力されることを確認。
    - 確認が完了したら、#のコメントアウトを戻してください。
4. 投稿の成功とフラッシュメッセージの確認。
    - 3番での入力内容が引き継がれていると思われるので、そのまま「投稿」をクリックする。
    - 「投稿の作成に成功しました」というフラッシュメッセージが出力されることを確認。
5. ヘッダーから「募集一覧」をクリックして、投稿内容が表示されていることを確認する。
    - 投稿した内容が表示されていることを確認する。
6. ヘッダーから「マイエリア」をクリックして、自分の投稿のみが表示されていることを確認する。
    - 投稿した内容のみが、表示されていることを確認する。

### チェックリスト
2. 投稿のバリデーションエラー
    - [x] タイトル：タイトルは少なくとも5文字以上必要です。
    - [x] 開始日：開始日は必須です。
    - [x] 終了日：終了日は必須です。
    - [x] 募集概要：少なくとも10文字以上の入力が必要です。
3. 投稿の失敗によるフラッシュメッセージ
    - [x] 「投稿の作成に失敗しました」というフラッシュメッセージが出力されることを確認。
4. 投稿の成功とフラッシュメッセージの確認
    - [x] 投稿の作成に成功しました」というフラッシュメッセージが出力されることを確認。
6. 募集一覧の投稿内容
    - [x] 投稿した内容が表示されていることを確認する。
7. マイエリアの投稿内容
    - [x] 投稿した内容のみが、表示されていることを確認する。

以上となります。ご確認のほどよろしくお願い致します。