### PR TITLE
[add]front: Roomのページ,参加ボタン実装 back:Room及びRoomへの参加の実装

### DIFF
--- a/back/app/controllers/api/v1/posts_controller.rb
+++ b/back/app/controllers/api/v1/posts_controller.rb
@@ -1,6 +1,7 @@
 module Api
   module V1
     class PostsController < ApplicationController
+      before_action :set_current_user
       
       def index
         
@@ -17,12 +18,14 @@ module Api
 
       def show
         post = Post.includes(:category).find(params[:id])
+        is_poster = @current_user.id == post.user_id
         post_with_category_name = post.attributes.merge({ 
           'category_name' => post.category.name,
           'start_date' => post.formatted_start_date,
           'end_date' => post.formatted_end_date,
         })
-        render json: post_with_category_name
+        render json: { post: post_with_category_name, is_poster: is_poster }
+        
       end
     end
   end

--- a/back/app/controllers/api/v1/room_users_controller.rb
+++ b/back/app/controllers/api/v1/room_users_controller.rb
@@ -1,0 +1,40 @@
+
+# class Api::V1::RoomUsersController < ApplicationController
+#   before_action :set_current_user
+
+#   def create
+#     post = Post.find(params[:post_id])
+#     room = post.room
+#     room_user = @current_user.room_users.new(room_id: room.id)
+
+#     if room_user.save
+#       render json: { message: "参加成功" }, status: :ok
+#     else
+#       render json: { error: "参加失敗" }, status: :unprocessable_entity
+#     end
+#   end
+# end
+
+class Api::V1::RoomUsersController < ApplicationController
+  before_action :set_current_user
+
+  def create
+    post = Post.find(params[:post_id])
+    room = post.room
+    p room.room_users.count
+    p post.recruiting_count
+    
+
+    if room.room_users.count < post.recruiting_count
+      room_user = @current_user.room_users.new(room_id: room.id)
+      if room_user.save
+        render json: { message: "参加成功" }, status: :ok
+      else
+        render json: { error: "参加失敗" }, status: :unprocessable_entity
+      end
+    else
+      Rails.logger.info "参加失敗: 現在の参加者数 #{room.room_users.count} / 募集人数 #{post.recruiting_count}"
+  
+    end
+  end
+end

--- a/back/app/controllers/api/v1/rooms_controller.rb
+++ b/back/app/controllers/api/v1/rooms_controller.rb
@@ -1,0 +1,22 @@
+class Api::V1::RoomsController < ApplicationController
+  def show
+    post = Post.find(params[:post_id])
+    @room = post.room
+    if @room
+      render json: { room: @room, post: post }
+    else
+      render json: { error: "Room not found" }, status: :not_found
+    end
+  end
+
+  def status
+    post = Post.find(params[:post_id])
+
+    if post && post.room
+      post.room.update_room_status # ステータスを更新する場合
+      render json: { status: post.room.status }
+    else
+      render json: { error: "Room not found" }, status: :not_found
+    end
+  end
+end

--- a/back/app/controllers/api/v1/user_posts_controller.rb
+++ b/back/app/controllers/api/v1/user_posts_controller.rb
@@ -17,6 +17,7 @@ class Api::V1::UserPostsController < ApplicationController
     post = @current_user.posts.new(post_params)
 
     if post.save
+      @room = post.create_room
       success_message = I18n.t('flash.posts.create.success')
       render json: { status: 'success', message: success_message, data: post }, status: :created
     else
@@ -25,7 +26,18 @@ class Api::V1::UserPostsController < ApplicationController
     end
   end
 
+  def edit_form
+    post = Post.includes(:category).find(params[:id])
+    post_with_category_name = post.attributes.merge({ 
+      'category_name' => post.category.name,
+      'start_date' => post.formatted_start_date,
+      'end_date' => post.formatted_end_date,
+    })
+    render json: post_with_category_name
+  end
+
   def update
+    p params
     post = @current_user.posts.find_by(id: params[:id])
 
     if post.update(post_params)

--- a/back/app/models/post.rb
+++ b/back/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :category
+  has_one :room, dependent: :destroy
 
   validates :category_id, presence: true
   validates :title, presence: true, length: { minimum: 5, maximum: 100 }

--- a/back/app/models/room.rb
+++ b/back/app/models/room.rb
@@ -1,0 +1,23 @@
+class Room < ApplicationRecord
+  enum status: { open: 0, full: 1 } # 0参加, 1満員
+  belongs_to :post
+  has_many :room_users, dependent: :destroy
+
+  after_create :add_creator_to_room_users
+
+  # 部屋の満員状態を確認して、更新するメソッド
+  def update_room_status
+    if room_users.count < post.recruiting_count
+      open!
+    else
+      full!
+    end
+  end
+
+  private
+
+  # RoomUserのレコード作成（参加）
+  def add_creator_to_room_users
+    room_users.create(user_id: post.user_id)
+  end
+end

--- a/back/app/models/room_user.rb
+++ b/back/app/models/room_user.rb
@@ -1,0 +1,4 @@
+class RoomUser < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,3 +1,5 @@
 class User < ApplicationRecord
   has_many :posts
+  has_many :room_users
+  
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -2,8 +2,15 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'api/v1/users#create'
   namespace :api do
     namespace :v1 do
-      resources :posts, only: [:index, :create, :show, :update, :destroy]
-      resources :user_posts, only: [:index, :create, :show, :update, :destroy]
+      resources :posts, only: [:index, :create, :show, :update, :destroy] do
+        get 'room_status', to: 'rooms#status'
+        resource :room do
+          resource :room_user
+        end
+      end
+      resources :user_posts, only: [:index, :create, :show, :update, :destroy] do
+        get 'edit_form', on: :member
+      end
     end
   end
 end

--- a/back/db/migrate/20240117103530_create_rooms.rb
+++ b/back/db/migrate/20240117103530_create_rooms.rb
@@ -1,0 +1,9 @@
+class CreateRooms < ActiveRecord::Migration[7.0]
+  def change
+    create_table :rooms do |t|
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/migrate/20240117104716_create_room_users.rb
+++ b/back/db/migrate/20240117104716_create_room_users.rb
@@ -1,0 +1,10 @@
+class CreateRoomUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :room_users do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/migrate/20240118090305_add_unique_index_to_room_users.rb
+++ b/back/db/migrate/20240118090305_add_unique_index_to_room_users.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToRoomUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_index :room_users, [:user_id, :room_id], unique: true
+  end
+end

--- a/back/db/migrate/20240119061134_add_status_to_rooms.rb
+++ b/back/db/migrate/20240119061134_add_status_to_rooms.rb
@@ -1,0 +1,5 @@
+class AddStatusToRooms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :rooms, :status, :integer, default: 0, null: false
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_03_144431) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_19_061134) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,6 +35,24 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_03_144431) do
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
+  create_table "room_users", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["room_id"], name: "index_room_users_on_room_id"
+    t.index ["user_id", "room_id"], name: "index_room_users_on_user_id_and_room_id", unique: true
+    t.index ["user_id"], name: "index_room_users_on_user_id"
+  end
+
+  create_table "rooms", force: :cascade do |t|
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
+    t.index ["post_id"], name: "index_rooms_on_post_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "provider", null: false
     t.string "avatar_url", null: false
@@ -47,4 +65,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_03_144431) do
 
   add_foreign_key "posts", "categories"
   add_foreign_key "posts", "users"
+  add_foreign_key "room_users", "rooms"
+  add_foreign_key "room_users", "users"
+  add_foreign_key "rooms", "posts"
 end

--- a/front/src/app/api/auth/[...nextauth]/route.ts
+++ b/front/src/app/api/auth/[...nextauth]/route.ts
@@ -51,6 +51,7 @@ const handler = NextAuth({
 		async session({ session, token }) {
 			if (token.accessToken && token.id) {
 				session.accessToken = token.accessToken as string;
+				session.user = token.id
 			}
 			return session;
 		},

--- a/front/src/app/components/ConfirmationModal.tsx
+++ b/front/src/app/components/ConfirmationModal.tsx
@@ -1,0 +1,36 @@
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  message: React.ReactNode;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+
+
+const ConfirmationModal = ({ isOpen, message, onConfirm, onCancel }: ConfirmationModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full flex justify-center items-center">
+      <div className="bg-white rounded-lg shadow-md p-4 max-w-sm mx-auto">
+        <p className="text-gray-800 text-lg">{message}</p>
+        <div className="flex justify-around mt-4">
+          <button 
+            onClick={onConfirm} 
+            className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            OK
+          </button>
+          <button 
+            onClick={onCancel} 
+            className="bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+          >
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmationModal;

--- a/front/src/app/components/DeletePostButton.tsx
+++ b/front/src/app/components/DeletePostButton.tsx
@@ -6,6 +6,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { getSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation'
 
+
 interface DeletePostButtonProps {
   id: number;
   apiUrl: any;

--- a/front/src/app/components/JoinRoomButton.tsx
+++ b/front/src/app/components/JoinRoomButton.tsx
@@ -1,0 +1,14 @@
+const JoinRoomButton = ({  onClick, status }) => {
+  return (
+    <button
+      onClick={onClick}
+      className={status === 'full' ? 'bg-gray-500' : 'bg-blue-600 hover:bg-blue-700'}
+      
+    >
+      {status == 'full' ? '閲覧' : '参加'}
+
+    </button>
+  )
+}
+
+export default JoinRoomButton

--- a/front/src/app/components/JoinRoomButton.tsx
+++ b/front/src/app/components/JoinRoomButton.tsx
@@ -1,4 +1,11 @@
-const JoinRoomButton = ({  onClick, status }) => {
+type RoomStatus = 'full' | 'open' | 'closed テスト';
+
+interface JoinRoomButtonProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+  status: RoomStatus;
+}
+
+const JoinRoomButton: React.FC<JoinRoomButtonProps> = ({  onClick, status  }) => {
   return (
     <button
       onClick={onClick}

--- a/front/src/app/hooks/useJoinRoom.tsx
+++ b/front/src/app/hooks/useJoinRoom.tsx
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { getSession } from 'next-auth/react';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+import { useRouter, useSearchParams, useParams } from 'next/navigation';
+
+const useJoinRoom = (postId: any) => {
+  
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+  const url = `${apiUrl}/api/v1/posts/${postId}/room/room_user`
+  const router = useRouter();
+
+  const joinRoom = async () => {
+
+    try {
+      const session = await getSession();
+      const token = session?.accessToken;
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const response = await axios.post(url,{}, {
+        headers: headers,
+        withCredentials: true
+      });
+      toast.success(response.data.message);
+      router.push(`/posts/${postId}/room`);
+    } catch (error: unknown) {
+      // エラーオブジェクトがAxiosError型のインスタンスであるかをチェック
+      if (axios.isAxiosError(error)) {
+        console.log(error)
+        // エラーレスポンスが存在し、その中にメッセージがある場合は表示する
+        if (error.response && error.response.data && typeof error.response.data.message === 'string') {
+          toast.error(error.response.data.message);
+        } else {
+          // その他のエラーの場合は汎用的なメッセージを表示
+          toast.error("参加に問題が発生しました");
+        }
+      }
+    }
+  }
+  return joinRoom
+}
+
+export default useJoinRoom

--- a/front/src/app/hooks/useRoomStatus.tsx
+++ b/front/src/app/hooks/useRoomStatus.tsx
@@ -1,0 +1,19 @@
+import useSWR from 'swr';
+import { useSession } from 'next-auth/react';
+import fetcherWithAuth from '../utils/fetcher';
+
+const useRoomStatus = (postId: any) => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+  const url = `${apiUrl}/api/v1/posts/${postId}/room_status`
+  // const { data: session, status } = useSession();
+  const { data: room, error } = useSWR(url, fetcherWithAuth); // fetcherWithAuthを使用
+  // const posts = rawPosts ? rawPosts.map((post :Post) => camelcaseKeys(post, {deep:true})) : null;
+
+  return {
+    roomStatus: room?.status,
+    isLoading: !error && !room,
+    isError: error
+  }
+}
+
+export default useRoomStatus

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import useSWR from 'swr';
+import fetcherWithAuth from '../../../utils/fetcher';
+import { useRouter, useSearchParams, useParams } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import camelcaseKeys from "camelcase-keys";
+import Image from 'next/image'
+
+const Room = () => {
+  const { data: session, status } = useSession();
+  const params = useParams()
+  const id = params.id
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+  const url = `${apiUrl}/api/v1/posts/${id}/room`
+
+  const { data: rawRoom, error } = useSWR(url, fetcherWithAuth);
+  console.log(rawRoom)
+  const room = rawRoom ? camelcaseKeys(rawRoom, {deep:true}) : null;
+
+  if (status === "loading") {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <Image src="/loading.svg" width={500} height={500} alt="loading..." className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) return <p className="text-center text-red-500">エラーが発生しました。</p>;
+
+  if (!room) {
+    return <div>Loading...</div>;
+  }
+
+  const roomTitle = room?.post?.title || 'タイトル未設定';
+
+  return (
+    <>
+      <p>{room?.post?.title}</p>
+      <p>{room?.post?.recruitingCount}</p>
+    </>
+  )
+
+}
+
+export default Room;

--- a/front/src/app/user/posts/[id]/edit/page.tsx
+++ b/front/src/app/user/posts/[id]/edit/page.tsx
@@ -15,6 +15,7 @@ import 'react-toastify/dist/ReactToastify.css';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from "zod";
 
+
 const postSchema = z.object({
   title: z.string().min(2, { message: "タイトルは少なくとも5文字以上必要です。" }),
   start_date: z.string().nonempty({ message: "開始日は必須です。" }),
@@ -54,9 +55,10 @@ export default function EditPost() {
   const params = useParams()
   const id = params.id
   const apiUrl = process.env.NEXT_PUBLIC_API_URL
-  const url = `${apiUrl}/api/v1/posts/${id}`
+  const url = `${apiUrl}/api/v1/user_posts/${id}/edit_form`
   const { data: rawPost, error } = useSWR<Post>(url, fetcherWithAuth);
   const post = rawPost ? camelcaseKeys(rawPost, {deep:true}) : null;
+  const router = useRouter();
 
   // データを取得して、初期値をフォームにセット
   const { register, handleSubmit, setValue, formState: { errors } } = useForm<FormData>({
@@ -76,6 +78,7 @@ export default function EditPost() {
 }, [post, setValue]);
 
   const editPost = async (formData :FormData) => {
+    
     const formDataRecord = {...formData};
     const session = await getSession();
     const token = session?.accessToken;
@@ -92,7 +95,13 @@ export default function EditPost() {
         headers: headers,
         withCredentials: true
       });
-      toast.success(response.data.message);
+      
+      router.push(`/posts/${id}`);
+      setTimeout(() => {
+        // 少し遅延させる 
+        toast.success(response.data.message);
+      }, 500);
+
 
     } catch (error: unknown) {
       // エラーオブジェクトがAxiosError型のインスタンスであるかをチェック


### PR DESCRIPTION
## 概要
Roomの実装。
募集投稿時に紐づくRoomが作成される。

## フロントエンド
- Roomのpageを作成。
- Roomに参加するためのボタンを実装。
  - 満員時に閲覧に切り替え

## バックエンド
- RoomとRoomUsersのモデル及びコントローラー実装
- 投稿時にRoomとの紐付け及びRoomUserにレコードが作成されるよう実装。
- enumでボタン（参加、閲覧）実装
- 人数制限用のメソッド実装