### PR TITLE
[add]front:メッセージコンポーネント実装 back:メッセージのindexのエンドポイント実装

### DIFF
--- a/back/app/controllers/api/v1/messages_controller.rb
+++ b/back/app/controllers/api/v1/messages_controller.rb
@@ -1,0 +1,9 @@
+class Api::V1::MessagesController < ApplicationController
+  before_action :set_current_user
+
+  def index
+    room = Room.find(params[:room_id])
+    messages = room.messages.includes(:user).order(created_at: :desc)
+    render json: messages.as_json(include: { user: { only: [:id, :name] } })
+  end
+end

--- a/back/app/controllers/messages_controller.rb
+++ b/back/app/controllers/messages_controller.rb
@@ -1,0 +1,3 @@
+class MessagesController < ApplicationController
+  
+end

--- a/back/app/models/message.rb
+++ b/back/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :user
+  belongs_to :room
+end

--- a/back/app/models/room.rb
+++ b/back/app/models/room.rb
@@ -2,6 +2,7 @@ class Room < ApplicationRecord
   enum status: { open: 0, full: 1 } # 0参加, 1満員
   belongs_to :post
   has_many :room_users, dependent: :destroy
+  has_many :messages
 
   after_create :add_creator_to_room_users
 

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
   has_many :posts
   has_many :room_users
-  
+  has_many :messages
 end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -2,15 +2,22 @@ Rails.application.routes.draw do
   post 'auth/:provider/callback', to: 'api/v1/users#create'
   namespace :api do
     namespace :v1 do
+
       resources :posts, only: [:index, :create, :show, :update, :destroy] do
         get 'room_status', to: 'rooms#status'
         resource :room do
           resource :room_user
         end
       end
+
       resources :user_posts, only: [:index, :create, :show, :update, :destroy] do
         get 'edit_form', on: :member
       end
+
+      resources :rooms, only: [] do
+        resources :messages
+      end
+      
     end
   end
 end

--- a/back/db/migrate/20240120045517_create_messages.rb
+++ b/back/db/migrate/20240120045517_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :messages do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :room, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/back/db/schema.rb
+++ b/back/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_19_061134) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_20_045517) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,16 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_19_061134) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.text "content", null: false
+    t.bigint "user_id", null: false
+    t.bigint "room_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["room_id"], name: "index_messages_on_room_id"
+    t.index ["user_id"], name: "index_messages_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -63,6 +73,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_19_061134) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "messages", "rooms"
+  add_foreign_key "messages", "users"
   add_foreign_key "posts", "categories"
   add_foreign_key "posts", "users"
   add_foreign_key "room_users", "rooms"

--- a/front/src/app/components/RoomMessages.tsx
+++ b/front/src/app/components/RoomMessages.tsx
@@ -1,0 +1,106 @@
+import useSWR from 'swr';
+import fetcherWithAuth from '../utils/fetcher';
+import { useSession } from 'next-auth/react';
+import camelcaseKeys from "camelcase-keys";
+import Image from 'next/image';
+import React, { useEffect, useRef, useState } from 'react';
+
+interface RoomMessagesProps {
+  roomId: string;
+}
+interface Message {
+  id: number;
+  content: string;
+  user: {
+    name: string;
+    id: number;
+  };
+  isSender: boolean;
+}
+
+const RoomMessages: React.FC<RoomMessagesProps> = ({ roomId }) => {
+  const { data: session, status } = useSession();
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const initialMessagesUrl = `${apiUrl}/api/v1/rooms/${roomId}/messages`;
+  const [messages, setMessages] = useState<Message[]>([]);
+  const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const [isAtBottom, setIsAtBottom] = useState(true);
+
+  const { data: rawMessages, error } = useSWR(initialMessagesUrl, fetcherWithAuth, {
+    onSuccess: (data) => {
+      const reversedData = camelcaseKeys(data, { deep: true }).reverse();
+      setMessages(reversedData);
+    }
+  });
+
+  const handleScroll = () => {
+    if (messagesContainerRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = messagesContainerRef.current;
+      const atBottom = scrollTop + clientHeight === scrollHeight;
+      setIsAtBottom(atBottom);
+    }
+  };
+
+  useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.addEventListener('scroll', handleScroll);
+      return () => container.removeEventListener('scroll', handleScroll);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (isAtBottom) {
+      const container = messagesContainerRef.current;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+  }, [messages, isAtBottom]);
+
+  if (status === "loading") {
+    return (
+      <div className="flex justify-center items-center h-screen">
+        <Image src="/loading.svg" width={500} height={500} alt="loading..." className="animate-spin" />
+      </div>
+    );
+  }
+
+  if (error) return <p className="text-center text-red-500">エラーが発生しました。</p>;
+
+  return (
+    <div className="flex flex-col h-auto max-h-[65vh] mx-auto mt-4 mb-4 p-4 bg-gray-200 rounded-lg">
+      {/* メッセージ表示部分 */}
+      <div className="flex flex-col space-y-2 overflow-auto" ref={messagesContainerRef}>
+        {messages.map((message) => (
+          <div
+            key={message.id}
+            className={`break-words bg-white p-2 rounded-lg shadow ${message.isSender ? 'ml-auto' : 'mr-auto'}`}
+            style={{ maxWidth: '75%', minWidth: '10%' }}
+          >
+            <p className="text-sm font-medium">{message.user?.name}</p>
+            <p className="text-sm">{message.content}</p>
+          </div>
+        ))}
+      </div>
+  
+      {/* ボタンと入力フィールド */}
+      <div className="mt-4">
+        <div className="flex items-center space-x-2">
+          <input
+            type="text"
+            className="flex-1 p-2 border rounded-lg"
+            placeholder="Type a message..."
+          />
+          <button
+            className="px-4 py-2 bg-blue-500 text-white rounded-lg"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default RoomMessages;

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams, useParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import camelcaseKeys from "camelcase-keys";
 import Image from 'next/image'
+import RoomMessages from '../../../components/RoomMessages'
 
 const Room = () => {
   const { data: session, status } = useSession();
@@ -14,9 +15,11 @@ const Room = () => {
   const apiUrl = process.env.NEXT_PUBLIC_API_URL
   const url = `${apiUrl}/api/v1/posts/${id}/room`
 
-  const { data: rawRoom, error } = useSWR(url, fetcherWithAuth);
-  console.log(rawRoom)
-  const room = rawRoom ? camelcaseKeys(rawRoom, {deep:true}) : null;
+  const { data: rawResponse, error } = useSWR(url, fetcherWithAuth);
+  const responce = rawResponse ? camelcaseKeys(rawResponse, {deep:true}) : null;
+  
+  const post = responce?.post 
+  const room = responce?.room
 
   if (status === "loading") {
     return (
@@ -35,12 +38,14 @@ const Room = () => {
   const roomTitle = room?.post?.title || 'タイトル未設定';
 
   return (
-    <>
-      <p>{room?.post?.title}</p>
-      <p>{room?.post?.recruitingCount}</p>
-    </>
-  )
+    <div className="container mx-auto p-4">
+      <h1 className="text-2xl font-bold">{post?.title}</h1>
+      <p className="text-md">Recruiting: {post?.recruitingCount}</p>
+      <RoomMessages roomId={room.id} />
+    </div>
+  );
 
 }
 
 export default Room;
+

--- a/front/src/app/user/posts/page.tsx
+++ b/front/src/app/user/posts/page.tsx
@@ -25,7 +25,7 @@ export default function UserPosts() {
   const url = `${apiUrl}/api/v1/user_posts`
   const { data: session, status } = useSession();
   const { data: rawPosts, error } = useSWR(url, fetcherWithAuth); // fetcherWithAuthを使用
-  const posts = rawPosts ? rawPosts.map((post :Post) => camelcaseKeys(post, {deep:true})) : null;
+  const posts = rawPosts ? camelcaseKeys(rawPosts, { deep: true }) : null;
 
   if (status === "loading") {
     return (


### PR DESCRIPTION
## 概要
チャットルームのメッセージ機能の実装

close #51 

## フロントエンド
- メッセージのコンポーネント化
- メッセージのスクロールの実装

## バックエンド
- Messageモデルの実装
- メッセージを取得するMessagesコントローラーのindex部分の実装