### PR TITLE
[add]ActionCable用の送受信用コードの実装

### DIFF
--- a/back/app/channels/chat_channel.rb
+++ b/back/app/channels/chat_channel.rb
@@ -1,0 +1,15 @@
+class ChatChannel < ApplicationCable::Channel
+  def subscribed
+    # stream_from "some_channel"
+    stream_from "chat_channel_#{params[:room_id]}"
+  end
+
+  def speak(data)
+    ActionCable.server.broadcast "chat_channel_#{params[:room_id]}", message: data['message']
+    
+  end
+
+  def unsubscribed
+    # Any cleanup needed when channel is unsubscribed
+  end
+end

--- a/back/config/routes.rb
+++ b/back/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount ActionCable.server => '/cable'
   post 'auth/:provider/callback', to: 'api/v1/users#create'
   namespace :api do
     namespace :v1 do

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -14,6 +14,7 @@
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.1.1",
         "@hookform/resolvers": "^3.3.4",
+        "actioncable": "^5.2.8-1",
         "axios": "^1.6.2",
         "camelcase-keys": "^9.1.2",
         "ewr": "^1.0.0",
@@ -29,6 +30,7 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
+        "@types/actioncable": "^5.2.11",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -571,6 +573,12 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@types/actioncable": {
+      "version": "5.2.11",
+      "resolved": "https://registry.npmjs.org/@types/actioncable/-/actioncable-5.2.11.tgz",
+      "integrity": "sha512-aGzv5JS3razLvv4ZJW+wlDuNS5y1IFFVlm1EkZq3ZHs6txju7/2iee1e6sdK6DE4zsz8cIREs1K4BtfF5RMESQ==",
+      "dev": true
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -746,6 +754,11 @@
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
+    },
+    "node_modules/actioncable": {
+      "version": "5.2.8-1",
+      "resolved": "https://registry.npmjs.org/actioncable/-/actioncable-5.2.8-1.tgz",
+      "integrity": "sha512-p/a9jeFs3KB3SWZ9w/T5HLyztooYSufOG++Uhau9YzprdBNyjFfsqrtN1roVVEzNDBGZJVr/2SSWwofvavPL1w=="
     },
     "node_modules/ajv": {
       "version": "6.12.6",

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,7 @@
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "@hookform/resolvers": "^3.3.4",
+    "actioncable": "^5.2.8-1",
     "axios": "^1.6.2",
     "camelcase-keys": "^9.1.2",
     "ewr": "^1.0.0",
@@ -30,6 +31,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/actioncable": "^5.2.11",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/front/src/app/components/RoomMessages.tsx
+++ b/front/src/app/components/RoomMessages.tsx
@@ -39,10 +39,11 @@ const RoomMessages: React.FC<RoomMessagesProps> = ({ roomId }) => {
   // メッセージ送信用hooks
   const createMessage = useCreateMessage(roomId);
   const [messageText, setMessageText] = useState("");
+  const websocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET
 
 
   useEffect(() => {
-    const cable = ActionCable.createConsumer('ws://localhost:3001/cable');
+    const cable = ActionCable.createConsumer(`${websocketUrl}/cable`);
     console.log(cable)
     const subscription = cable.subscriptions.create(
       { channel: 'ChatChannel', room_id: roomId },


### PR DESCRIPTION
## 概要
ActionCabelによるリアルタイムチャットの実装
送信分の実装

released #16 

## フロントエンド
`npm install actioncable`
送受信のコードを実装
websocket用URLを環境変数に設定

## バックエンド
`rails generate channel Chat`
送受信用のコードを実装

