### PR TITLE
[fix] 新規募集投稿時の画面遷移をルームに変更及びアニメーション実装

### DIFF
--- a/front/src/app/globals.css
+++ b/front/src/app/globals.css
@@ -1,3 +1,15 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+@keyframes blink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+.blink {
+  animation: blink 1s linear infinite;
+}

--- a/front/src/app/layout.tsx
+++ b/front/src/app/layout.tsx
@@ -4,6 +4,8 @@ import './globals.css'
 import NextAuthProvider from '@/providers/NextAuth';
 import Header from './components/Header';
 import Footer from './components/Footer';
+import { Poppins } from "next/font/google";
+const HachiMaruPopFont = Poppins({ weight: "500", subsets: ["latin"] });
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -19,7 +21,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className={`${inter.className} flex flex-col min-h-screen`}>
+      <body className={`${HachiMaruPopFont.className} flex flex-col min-h-screen`}>
         <NextAuthProvider>
           <Header />
             <main className="flex-1">

--- a/front/src/app/user/posts/new/page.tsx
+++ b/front/src/app/user/posts/new/page.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import React from 'react';
+import { useState } from 'react';
 import axios from 'axios';
 import { getSession } from 'next-auth/react';
+import { useRouter, useSearchParams, useParams } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from "zod";
@@ -49,9 +50,13 @@ export default function PostForm() {
   const { register, handleSubmit, formState: { errors } } = useForm<FormData>({
     resolver: zodResolver(postSchema),
   });
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
 
   const createPost = async (formData :FormData) => {
     const formDataRecord = { ...formData };
+    setIsLoading(true);
+    
     // フォームのバリデーションなどのロジックをここに追加
     //if (!title || !startDate || !endDate || !description) return;
     const session = await getSession();
@@ -73,9 +78,14 @@ export default function PostForm() {
         withCredentials: true
       });
       toast.success(response.data.message);
+      setTimeout(() => {
+        router.push(`/posts/${response.data.data.id}/room`);
+        setIsLoading(false);
+      }, 5000);
 
     } catch (error: unknown) {
       // エラーオブジェクトがAxiosError型のインスタンスであるかをチェック
+      setIsLoading(false); // ローディング終了
       if (axios.isAxiosError(error)) {
         console.log(error)
         // エラーレスポンスが存在し、その中にメッセージがある場合は表示する
@@ -91,6 +101,14 @@ export default function PostForm() {
 
   return (
     <div className="container mx-auto p-8 bg-gradient-to-r from-blue-50 to-blue-100">
+       {isLoading && (
+        <div className="fixed inset-0 bg-black bg-opacity-70 flex flex-col justify-center items-center">
+          <div className="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-blue-500"></div>
+          <h2 className="mt-5 text-2xl text-white blink">
+            チャットルームを作成中です...
+          </h2>
+        </div>
+      )}
       <div className="max-w-3xl mx-auto bg-white p-8 shadow-2xl rounded-xl">
         <h2 className="text-4xl font-bold mb-10 text-center text-gray-800 flex justify-center items-center">
           <AiOutlineTeam className="mr-2" />


### PR DESCRIPTION
## 概要
新規募集投稿時の画面遷移をルームに変更
画面遷移時のアニメーション実装

## フロントエンド
新規募集投稿時に紐づくルームが作成されるため、そちらに画面遷移するように変更。
ユーザーが視覚的にわかりやすいように、チャットルームを作成中のアニメーションを追加。