### PR TITLE
[fix]部屋の表示内容の修正

### DIFF
--- a/back/app/controllers/api/v1/rooms_controller.rb
+++ b/back/app/controllers/api/v1/rooms_controller.rb
@@ -6,10 +6,11 @@ class Api::V1::RoomsController < ApplicationController
     @room = post.room
     if @room
       is_creator = @current_user.id == post.user_id
+      is_participant = @room.users.exists?(@current_user.id)
       user_names = @room.users.map(&:name)
       avatar_urls = @room.users.map(&:avatar_url)
       participant_count = @room.current_participant_count
-      render json: { room: @room, post: post, isCreator: is_creator, userNames: user_names, participantCount: participant_count, avatarUrls: avatar_urls }
+      render json: { room: @room, post: post, isCreator: is_creator, isParticipant: is_participant, userNames: user_names, participantCount: participant_count, avatarUrls: avatar_urls }
     else
       render json: { error: "Room not found" }, status: :not_found
     end

--- a/back/app/controllers/api/v1/rooms_controller.rb
+++ b/back/app/controllers/api/v1/rooms_controller.rb
@@ -7,8 +7,9 @@ class Api::V1::RoomsController < ApplicationController
     if @room
       is_creator = @current_user.id == post.user_id
       user_names = @room.users.map(&:name)
+      avatar_urls = @room.users.map(&:avatar_url)
       participant_count = @room.current_participant_count
-      render json: { room: @room, post: post, isCreator: is_creator, userNames: user_names, participantCount: participant_count }
+      render json: { room: @room, post: post, isCreator: is_creator, userNames: user_names, participantCount: participant_count, avatarUrls: avatar_urls }
     else
       render json: { error: "Room not found" }, status: :not_found
     end

--- a/front/src/app/posts/[id]/page.tsx
+++ b/front/src/app/posts/[id]/page.tsx
@@ -138,7 +138,9 @@ export default function DetailPost() {
           {!isPoster && (
             <div className="flex">
               {isJoined ? (
-                <button onClick={() => viewOnlyRoom()}>
+                <button onClick={() => viewOnlyRoom()}
+                className="bg-gray-500 hover:bg-gray-600 text-white font-bold py-2 px-4 rounded"
+                >
                   参加済み
                 </button>
               ) : (

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -59,7 +59,7 @@ const Room = () => {
   const userNames: string[] = responce?.userNames || [];
   const users = userNames.map((name: string, index: number) => ({
     name: name,
-    avatarUrl: responce?.avatarUrls[index] // avatarUrlsも同様に、undefinedの場合を考慮
+    avatarUrl: responce?.avatarUrls[index]
   }));
 
   if (status === "loading") {
@@ -113,15 +113,37 @@ const Room = () => {
         </div>
       )}
 
-      {/* 投稿者のみ退出ボタンを非公開 */}
-      {!isCreator && isParticipant && (
-        <button
-          onClick={handleModalOpen}
-          className="inline-flex items-center px-4 py-2 border border-gray-600 text-sm font-medium rounded-md text-gray-600 bg-white hover:bg-gray-100"
-        >
-          退出
-        </button>
-      )}
+      <div className="flex justify-center my-4">
+        <div className="bg-gradient-to-r from-blue-100 via-gray-300 to-blue-100 text-gray-800 p-4 rounded shadow-lg max-w-md text-center">
+          {isCreator ? (
+            <p>管理者：あなたは部屋の管理者です。</p>
+          ) : isParticipant ? (
+            <p>ステータス：参加中</p>
+          ) : (
+            <div>
+              <p>ステータス：閲覧中</p>
+              <p>閲覧中のためメッセージを送ることはできません</p>
+            </div>
+          )}
+        </div>
+      </div>
+      
+      {/* 投稿者と閲覧者は退出ボタンを非公開 */}
+      <div className="flex justify-end">
+        {!isCreator && isParticipant && (
+         <div className="flex justify-between items-center">
+          <p className="text-xs text-gray-600">
+            注意：退出ボタンを押すと、部屋から完全に退出し、メッセージを送信できなくなります。
+          </p>
+          <button
+            onClick={handleModalOpen}
+            className="inline-flex items-center px-4 py-2 border border-gray-600 text-sm font-medium rounded-md text-gray-600 bg-white hover:bg-gray-100"
+          >
+            退出
+          </button>
+       </div>
+        )}
+      </div>
       <Modal 
         isOpen={isModalOpen} 
         onClose={handleModalClose}

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -21,10 +21,12 @@ type User = {
 
 const Room = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const { data: session, status } = useSession();
   const params = useParams()
   const id = params.id
+  const router = useRouter();
   const apiUrl = process.env.NEXT_PUBLIC_API_URL
   const url = `${apiUrl}/api/v1/posts/${id}/room`
   
@@ -36,14 +38,21 @@ const Room = () => {
     const session = await getSession();
     const token = session?.accessToken;
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    
     try {
       const response = await axios.delete(`${apiUrl}/api/v1/posts/${id}/room`, {
         headers: headers,
         withCredentials: true
     });
+    setIsLoading(true);
     toast.success(response.data.message);
     setIsModalOpen(false);
+    setTimeout(() => {
+      router.push(`/posts`);
+      setIsLoading(false);
+    }, 3000);    
     } catch (error) {
+      setIsLoading(false);
       console.error("退出処理中にエラーが発生しました:", error);
     }
   }
@@ -85,6 +94,14 @@ const Room = () => {
 
   return (
     <div className="relative container mx-auto p-4">
+      {isLoading && (
+        <div className="fixed inset-0 bg-black bg-opacity-70 flex flex-col justify-center items-center">
+          <div className="animate-spin rounded-full h-32 w-32 border-t-2 border-b-2 border-blue-500"></div>
+          <h2 className="mt-5 text-2xl text-white blink">
+            チャットルームから退出中です。
+          </h2>
+        </div>
+      )}
       <div className="flex justify-between items-center mb-4">
         <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="flex flex-col justify-around w-8 h-6 z-50">
           <div className="w-full h-1 bg-black rounded"></div>

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -45,7 +45,7 @@ const Room = () => {
         withCredentials: true
     });
     setIsLoading(true);
-    toast.success(response.data.message);
+    // toast.success(response.data.message);
     setIsModalOpen(false);
     setTimeout(() => {
       router.push(`/posts`);

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -44,29 +44,23 @@ const Room = () => {
     toast.success(response.data.message);
     setIsModalOpen(false);
     } catch (error) {
-      // エラーが発生した場合の処理
       console.error("退出処理中にエラーが発生しました:", error);
     }
   }
 
   const { data: rawResponse, error } = useSWR(url, fetcherWithAuth);
   const responce = rawResponse ? camelcaseKeys(rawResponse, {deep:true}) : null;
-  console.log("あああ")
-  console.log(responce)
   
   const post = responce?.post
   const room = responce?.room
   const participantCount = responce?.participantCount
+  const isParticipant = responce?.isParticipant;
   const isCreator = responce?.isCreator;
   const userNames: string[] = responce?.userNames || [];
   const users = userNames.map((name: string, index: number) => ({
     name: name,
     avatarUrl: responce?.avatarUrls[index] // avatarUrlsも同様に、undefinedの場合を考慮
   }));
-
-  console.log("えええ")
-  console.log(responce)
-  
 
   if (status === "loading") {
     return (
@@ -120,7 +114,7 @@ const Room = () => {
       )}
 
       {/* 投稿者のみ退出ボタンを非公開 */}
-      {!isCreator && (
+      {!isCreator && isParticipant && (
         <button
           onClick={handleModalOpen}
           className="inline-flex items-center px-4 py-2 border border-gray-600 text-sm font-medium rounded-md text-gray-600 bg-white hover:bg-gray-100"
@@ -138,7 +132,6 @@ const Room = () => {
       <RoomMessages roomId={room.id} />
     </div>
   );
-
 }
 
 export default Room;

--- a/front/src/app/posts/[id]/room/page.tsx
+++ b/front/src/app/posts/[id]/room/page.tsx
@@ -58,7 +58,14 @@ const Room = () => {
   const room = responce?.room
   const participantCount = responce?.participantCount
   const isCreator = responce?.isCreator;
-  const userNames = responce?.userNames
+  const userNames: string[] = responce?.userNames || [];
+  const users = userNames.map((name: string, index: number) => ({
+    name: name,
+    avatarUrl: responce?.avatarUrls[index] // avatarUrlsも同様に、undefinedの場合を考慮
+  }));
+
+  console.log("えええ")
+  console.log(responce)
   
 
   if (status === "loading") {
@@ -97,16 +104,16 @@ const Room = () => {
       {isMenuOpen && (
         <div className="absolute top-14 left-0 right-0 bg-white shadow-lg rounded-lg p-4 z-40 transition-all duration-300">
           <p className="text-md">タイトル: {post?.title}</p>
-          <p className="text-md">人数: {post?.recruitingCount} / {participantCount}</p>
+          <p className="text-md">人数 :  {participantCount} / {post?.recruitingCount}</p>
           <div className="mt-3">
             <p className="font-semibold mb-2">参加者:</p>
             <div className="flex flex-col">
-              {userNames.map((user: User, index: number) => (
-                <div key={index} className="flex items-center mb-2">
-                  <Image src="/default-avatar.png" height={35} width={35} className="rounded-full" alt="User Avatar" />
-                  <p className="ml-2">{user.name}</p>
-                </div>
-              ))}
+            {users.map((user, index) => (
+              <div key={index} className="flex items-center mb-2">
+                <Image src={user.avatarUrl} height={30} width={30} className="rounded-full" alt="User Avatar" />
+                <p className="ml-2">{user.name}</p>
+              </div>
+            ))}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要
部屋に表示される表示内容を修正。

## フロントエンド
- ルームに参加者を表示。
- 参加者用の退出ボタンが、閲覧者ようにも表示されていたため、非表示に修正。
- 部屋の参加者のステータス状態を管理
- 部屋から退出する際にローディング画面を挟むよう修正。
